### PR TITLE
update for new handshake in post-message-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var Duplexify = require('duplexify')
 var PostMessageStream = require('post-message-stream')
 
 /*
@@ -13,20 +12,13 @@ module.exports = {
   ParentStream: ParentStream,
 }
 
-
 function IframeStream(iframe) {
   if (this instanceof IframeStream) throw Error('IframeStream - Dont construct via the "new" keyword.')
-  var duplexStream = Duplexify.obj()
-  iframe.addEventListener('load', function(){
-    var postMessageStream = new PostMessageStream({
-      name: 'iframe-parent',
-      target: 'iframe-child',
-      targetWindow: iframe.contentWindow,
-    })
-    duplexStream.setWritable(postMessageStream)
-    duplexStream.setReadable(postMessageStream)
+  return new PostMessageStream({
+    name: 'iframe-parent',
+    target: 'iframe-child',
+    targetWindow: iframe.contentWindow,
   })
-  return duplexStream
 }
 
 //

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "author": "kumavis",
   "license": "ISC",
   "dependencies": {
-    "duplexify": "^3.5.0",
     "post-message-stream": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this is dependent on https://github.com/kumavis/post-message-stream/pull/2

Since we have a handshake we on longer need to wait for the iframe to load. Waiting for the `load` event is buggy since the load event can fire before the source code in the iframe has ran. Also if the iframe, or the main window sets up the stream asyncoursly the 'load' event will not work